### PR TITLE
ignore Slack special commands

### DIFF
--- a/morgenbot.py
+++ b/morgenbot.py
@@ -289,8 +289,8 @@ def main():
 
     text = request.form.get("text", "")
 
-    # ignore if it doesn't start with !
-    match = re.findall(r"!(\S+)", text)
+    # find !command, but ignore <!command
+    match = re.findall(r"(?<!<)!(\S+)", text)
     if not match: return
 
     command = match[0]


### PR DESCRIPTION
Slack has some special commands. From the [docs](https://api.slack.com/docs/formatting):

> Some messages contain special words with extra behavior. For these we use the format `<!foo>`, where `foo` is a special command. Currently defined commands are `!channel`, `!group` and `!everyone` (group is just a synonym for channel - both can be used in channels and groups). These indicate an @channel, @group or @everyone message, and should cause a notification to be displayed by the client.

morgenbot should ignore `<!foo>` commands.

This patch ignores commands starting with `<` by adding a negative look behind to the regular expression.