### PR TITLE
Update 'python morgenbot.py' to CMD instead of run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 5000
 
 RUN pip install -r requirements.txt
 
-RUN python morgenbot.py
+CMD python morgenbot.py


### PR DESCRIPTION
RUN is used when setting up a docker image (eg the pip command). These are expected to exit.  CMD is the entry point when running the image. This is meant to be the long running process that you want to run with docker.
