### PR TITLE
Add support for skipping idle users

### DIFF
--- a/morgenbot.py
+++ b/morgenbot.py
@@ -31,12 +31,12 @@ giphy = True if os.getenv('GIPHY', 'false').lower() == 'true' else False
 commands = ['standup','start','cancel','next','skip','table','left','ignore','heed','ignoring','help']
 
 users = []
-idle_users = []
 topics = []
 time = []
 in_progress = False
 current_user = ''
 absent_users = []
+idle_users = []
 
 def post_message(text, attachments=[]):
     slack.chat.post_message(channel     = channel,
@@ -57,7 +57,6 @@ def get_channel(id):
                             
 def init():
     global users
-    global idle_users
     global topics
     global time
     global in_progress
@@ -65,8 +64,8 @@ def init():
     if len(users) != 0:
         post_message('Looks like we have a standup already in process.')
         return
+    idle_users = []
     users = standup_users()
-    idle_users = idle_users()
     topics = []
     time = []
     in_progress = True
@@ -74,13 +73,21 @@ def init():
 
 def start():
     global time
+    global users
+    global skip_idle_users
+    global idle_users
     
     if len(time) != 0:
         post_message('But we\'ve already started!')
         return
     time.append(datetime.datetime.now())
+
+    if skip_idle_users and idle_users:
+        post_message('Skipping idle users: @' + ', @'.join(idle_users))
+
     post_message('Let\'s get started! %s\nWhen you\'re done, please type !next' % start_message)
-    next()
+
+    next(None)
 
 def cancel():
     tabled()
@@ -98,7 +105,6 @@ def done():
     
 def reset():
     global users
-    global idle_users
     global topics
     global time
     global in_progress
@@ -114,6 +120,8 @@ def reset():
 def standup_users():
     global ignore_users
     global absent_users
+    global skip_idle_users
+    global idle_users
     
     ignore_users_array = eval(ignore_users)
 
@@ -131,29 +139,38 @@ def standup_users():
     for user_id in standup_users:
         user_name = slack.users.info(user_id).body['user']['name']
         is_deleted = slack.users.info(user_id).body['user']['deleted']
-        if not is_deleted and user_name not in ignore_users_array and user_name not in absent_users:
+        is_idle = skip_idle_users and slack.users.get_presence(user_id).body['presence'] != 'active'
+        if not is_idle and not is_deleted and user_name not in ignore_users_array and user_name not in absent_users:
             active_users.append(user_name)
+
+        if is_idle:
+            idle_users.append(user_name)
             
     # don't forget to shuffle so we don't go in the same order every day!
     random.shuffle(active_users)
     
     return active_users
 
-def next():
+def next(args):
     global users
     global current_user
-    global idle_users
     global skip_idle_users
-    
+
     if len(users) == 0:
         done()
     else:
-        current_user = users.pop()
-        if skip_idle_users and current_user in idle_users:
-            post_message('Skipping @%s (idle)' % current_user)
-            next()
+        if args:
+            args = args.strip()
+            next_user = args.split(' ')[0].replace('@', '')
+            if next_user in users:
+                current_user = users.pop(users.index(next_user))
+            else:
+                post_message('I don\'t recognize "%s". Moving on...' % args)
+                current_user = users.pop()
         else:
-            post_message('@%s, you\'re up' % current_user)
+            current_user = users.pop()
+
+        post_message('@%s, you\'re up' % current_user)
 
 def standup_time():
     if len(time) != 2: return
@@ -220,7 +237,7 @@ def ignoring():
 
 def skip():
     post_message('Skipping @%s.' % current_user)
-    next()
+    next(None)
 
 def table(topic_user, topic):
     global topics
@@ -261,26 +278,6 @@ def giphy(text):
         }]
     
         post_message('Not sure what "%s" is.' % text, json.dumps(attachments))
-
-def idle_users():
-    idle_users = []
-    channel_id = ''
-    channel_name = channel.replace('#', '') # for some reason we skip the # in this API call
-    all_channels = slack.channels.list(1) # 1 means we skip any archived rooms
-
-    for one_channel in all_channels.body['channels']:
-        if one_channel['name'] == channel_name:
-            channel_id = one_channel['id']
-
-    standup_room = slack.channels.info(channel_id).body['channel']
-    standup_users = standup_room['members']
-
-    for user_id in standup_users:
-        user_name = slack.users.info(user_id).body['user']['name']
-        if slack.users.get_presence(user_id).body['presence'] != 'active':
-            idle_users.append(user_name)
-
-    return idle_users
 
 def help(topic=''):
     if topic == '':
@@ -346,7 +343,7 @@ def main():
     elif command == 'cancel':
         cancel()
     elif command == 'next':
-        next()
+        next(args)
     elif command == 'skip':
         skip()
     elif command == 'table':

--- a/morgenbot.py
+++ b/morgenbot.py
@@ -46,22 +46,22 @@ def post_message(text, attachments=[]):
                             link_names  = 1,
                             attachments = attachments,
                             icon_emoji  = icon_emoji)
-
+                            
 def get_user(id):
     user = slack.users.info(id).body
     return user['user']['name']
-
+    
 def get_channel(id):
     channel = slack.channels.info(id).body
     return channel['channel']['name']
-
+                            
 def init():
     global users
     global idle_users
     global topics
     global time
     global in_progress
-
+     
     if len(users) != 0:
         post_message('Looks like we have a standup already in process.')
         return
@@ -74,7 +74,7 @@ def init():
 
 def start():
     global time
-
+    
     if len(time) != 0:
         post_message('But we\'ve already started!')
         return
@@ -86,16 +86,16 @@ def cancel():
     tabled()
     post_message('Standup is cancelled. Bye!')
     reset()
-
+    
 def done():
     global time
-
+    
     time.append(datetime.datetime.now())
     standup_time()
     tabled()
     post_message('Bye!')
     reset()
-
+    
 def reset():
     global users
     global idle_users
@@ -103,18 +103,18 @@ def reset():
     global time
     global in_progress
     global current_user
-
+    
     del users[:]
     del idle_users[:]
     del topics[:]
     del time[:]
     in_progress = False
     current_user = ''
-
+    
 def standup_users():
     global ignore_users
     global absent_users
-
+    
     ignore_users_array = eval(ignore_users)
 
     channel_id = '';
@@ -123,20 +123,20 @@ def standup_users():
     for one_channel in all_channels.body['channels']:
         if one_channel['name'] == channel_name:
             channel_id = one_channel['id']
-
+    
     standup_room = slack.channels.info(channel_id).body['channel']
     standup_users = standup_room['members']
     active_users = []
-
+    
     for user_id in standup_users:
         user_name = slack.users.info(user_id).body['user']['name']
         is_deleted = slack.users.info(user_id).body['user']['deleted']
         if not is_deleted and user_name not in ignore_users_array and user_name not in absent_users:
             active_users.append(user_name)
-
+            
     # don't forget to shuffle so we don't go in the same order every day!
     random.shuffle(active_users)
-
+    
     return active_users
 
 def next():
@@ -144,7 +144,7 @@ def next():
     global current_user
     global idle_users
     global skip_idle_users
-
+    
     if len(users) == 0:
         done()
     else:
@@ -164,18 +164,18 @@ def standup_time():
 def left():
     if len(users) == 0:
         post_message('That\'s everyone!')
-    else:
+    else:    
         post_message('Here\'s who\'s left: @' + ', @'.join(users))
-
+        
 def ignore(user):
     global ignore_users
     global absent_users
     active_users = standup_users()
-
+    
     if user == '':
         post_message('Who should I ignore?')
         return
-
+    
     user = user[1:]
     if user not in active_users and user not in ignore_users and user not in absent_users:
         post_message('I don\'t recognize that user.')
@@ -184,16 +184,16 @@ def ignore(user):
     elif user in active_users:
         absent_users.append(user)
         post_message('I won\'t call on @%s again until I am told to using !heed <username>.' % user)
-
+    
 def heed(user):
     global ignore_users
     global absent_users
     active_users = standup_users()
-
+    
     if user == '':
         post_message('Who should I heed?')
         return
-
+    
     user = user[1:]
     if user not in active_users and user not in ignore_users and user not in absent_users:
         post_message('I don\'t recognize that user.')
@@ -204,18 +204,18 @@ def heed(user):
     elif user in absent_users:
         absent_users.remove(user)
         post_message('I\'ll start calling on @%s again at the next standup.' % user)
-
+        
 def ignoring():
     global ignore_users
     global absent_users
-
+    
     if len(ignore_users) == 0 and len(absent_users) == 0:
         post_message('We\'re not ignoring anyone.')
         return
-
-    if len(ignore_users) != 0:
+        
+    if len(ignore_users) != 0:    
         post_message('Here\'s who we never call on: ' + ignore_users)
-    if len(absent_users) != 0:
+    if len(absent_users) != 0:    
         post_message('Here\'s who we\'re ignoring for now: ' + ', '.join(absent_users))
 
 def skip():
@@ -224,7 +224,7 @@ def skip():
 
 def table(topic_user, topic):
     global topics
-
+    
     channels = re.findall(r"<#(.*?)>", topic)
     users = re.findall(r"<@(.*?)>", topic)
 
@@ -235,7 +235,7 @@ def table(topic_user, topic):
     for user in users:
         user_name = get_user(user)
         topic = topic.replace('<@%s>' % user, '@%s' % user_name)
-
+    
     post_message('@%s: Tabled.' % topic_user)
     topics.append(str(topic))
 
@@ -244,12 +244,12 @@ def tabled():
     post_message('Tabled topics:')
     for topic in topics:
         post_message('-%s' % topic)
-
+        
 def giphy(text):
     url = 'http://api.giphy.com/v1/gifs/search?q=%s&api_key=dc6zaTOxFJmzC&limit=1' % urllib2.quote(text.encode("utf8"))
     response = urllib2.urlopen(url)
     data = json.loads(response.read())
-
+    
     if len(data['data']) == 0:
         post_message('Not sure what "%s" is.' % text)
     else:
@@ -259,7 +259,7 @@ def giphy(text):
             'title_link': data['data'][0]['url'],
             'image_url': data['data'][0]['images']['fixed_height']['url']
         }]
-
+    
         post_message('Not sure what "%s" is.' % text, json.dumps(attachments))
 
 def idle_users():
@@ -282,12 +282,11 @@ def idle_users():
 
     return idle_users
 
-
 def help(topic=''):
     if topic == '':
         post_message('My commands are !standup, !start, !cancel, !next, !skip, !table, !left, !ignore, !heed, and !ignoring.\nAsk me "!help <command> to learn what they do.')
         return
-
+        
     topic = topic[1:]
     if topic == 'standup' or topic == '!standup':
         post_message('Type !standup to initiate a new standup')
@@ -329,7 +328,7 @@ def main():
     command = match[0]
     args = text.replace("!%s" % command, '')
     command = command.lower()
-
+    
     if command not in commands:
         if giphy:
             giphy(text[1:])
@@ -339,7 +338,7 @@ def main():
     elif not in_progress and command != 'standup' and command != 'help' and command != 'ignore' and command != 'heed' and command != 'ignoring':
         post_message('Looks like standup hasn\'t started yet. Type !standup.')
         return json.dumps({ })
-
+        
     if command == 'standup':
         init()
     elif command == 'start':
@@ -362,7 +361,7 @@ def main():
         ignoring()
     elif command == 'help':
         help(args)
-
+        
     return json.dumps({ })
 
 if __name__ == "__main__":

--- a/morgenbot.py
+++ b/morgenbot.py
@@ -21,7 +21,6 @@ username = os.getenv('USERNAME', 'morgenbot')
 icon_emoji = os.getenv('ICON_EMOJI', ':coffee:')
 channel = os.getenv('CHANNEL', '#standup')
 ignore_users = os.getenv('IGNORE_USERS', '[]')
-skip_idle_users = False if os.getenv('SKIP_IDLE_USERS', 'true').lower() == 'false' else True
 
 init_greeting = os.getenv('INIT_GREETING', 'Good morning!')
 start_message = os.getenv('START_MESSAGE', 'What did you work on yesterday? What are you working on today? What, if any, are your blockers?')
@@ -31,7 +30,6 @@ giphy = True if os.getenv('GIPHY', 'false').lower() == 'true' else False
 commands = ['standup','start','cancel','next','skip','table','left','ignore','heed','ignoring','help']
 
 users = []
-idle_users = []
 topics = []
 time = []
 in_progress = False
@@ -46,27 +44,25 @@ def post_message(text, attachments=[]):
                             link_names  = 1,
                             attachments = attachments,
                             icon_emoji  = icon_emoji)
-
+                            
 def get_user(id):
     user = slack.users.info(id).body
     return user['user']['name']
-
+    
 def get_channel(id):
     channel = slack.channels.info(id).body
     return channel['channel']['name']
-
+                            
 def init():
     global users
-    global idle_users
     global topics
     global time
     global in_progress
-
+     
     if len(users) != 0:
         post_message('Looks like we have a standup already in process.')
         return
     users = standup_users()
-    idle_users = idle_users()
     topics = []
     time = []
     in_progress = True
@@ -74,7 +70,7 @@ def init():
 
 def start():
     global time
-
+    
     if len(time) != 0:
         post_message('But we\'ve already started!')
         return
@@ -86,35 +82,33 @@ def cancel():
     tabled()
     post_message('Standup is cancelled. Bye!')
     reset()
-
+    
 def done():
     global time
-
+    
     time.append(datetime.datetime.now())
     standup_time()
     tabled()
     post_message('Bye!')
     reset()
-
+    
 def reset():
     global users
-    global idle_users
     global topics
     global time
     global in_progress
     global current_user
-
+    
     del users[:]
-    del idle_users[:]
     del topics[:]
     del time[:]
     in_progress = False
     current_user = ''
-
+    
 def standup_users():
     global ignore_users
     global absent_users
-
+    
     ignore_users_array = eval(ignore_users)
 
     channel_id = '';
@@ -123,38 +117,32 @@ def standup_users():
     for one_channel in all_channels.body['channels']:
         if one_channel['name'] == channel_name:
             channel_id = one_channel['id']
-
+    
     standup_room = slack.channels.info(channel_id).body['channel']
     standup_users = standup_room['members']
     active_users = []
-
+    
     for user_id in standup_users:
         user_name = slack.users.info(user_id).body['user']['name']
         is_deleted = slack.users.info(user_id).body['user']['deleted']
         if not is_deleted and user_name not in ignore_users_array and user_name not in absent_users:
             active_users.append(user_name)
-
+            
     # don't forget to shuffle so we don't go in the same order every day!
     random.shuffle(active_users)
-
+    
     return active_users
 
 def next():
     global users
     global current_user
-    global idle_users
-    global skip_idle_users
-
+    
     if len(users) == 0:
         done()
     else:
         current_user = users.pop()
-        if skip_idle_users and current_user in idle_users:
-            post_message('Skipping @%s (idle)' % current_user)
-            next()
-        else:
-            post_message('@%s, you\'re up' % current_user)
-
+        post_message('@%s, you\'re up' % current_user)
+        
 def standup_time():
     if len(time) != 2: return
     seconds = (time[1] - time[0]).total_seconds()
@@ -164,18 +152,18 @@ def standup_time():
 def left():
     if len(users) == 0:
         post_message('That\'s everyone!')
-    else:
+    else:    
         post_message('Here\'s who\'s left: @' + ', @'.join(users))
-
+        
 def ignore(user):
     global ignore_users
     global absent_users
     active_users = standup_users()
-
+    
     if user == '':
         post_message('Who should I ignore?')
         return
-
+    
     user = user[1:]
     if user not in active_users and user not in ignore_users and user not in absent_users:
         post_message('I don\'t recognize that user.')
@@ -184,16 +172,16 @@ def ignore(user):
     elif user in active_users:
         absent_users.append(user)
         post_message('I won\'t call on @%s again until I am told to using !heed <username>.' % user)
-
+    
 def heed(user):
     global ignore_users
     global absent_users
     active_users = standup_users()
-
+    
     if user == '':
         post_message('Who should I heed?')
         return
-
+    
     user = user[1:]
     if user not in active_users and user not in ignore_users and user not in absent_users:
         post_message('I don\'t recognize that user.')
@@ -204,18 +192,18 @@ def heed(user):
     elif user in absent_users:
         absent_users.remove(user)
         post_message('I\'ll start calling on @%s again at the next standup.' % user)
-
+        
 def ignoring():
     global ignore_users
     global absent_users
-
+    
     if len(ignore_users) == 0 and len(absent_users) == 0:
         post_message('We\'re not ignoring anyone.')
         return
-
-    if len(ignore_users) != 0:
+        
+    if len(ignore_users) != 0:    
         post_message('Here\'s who we never call on: ' + ignore_users)
-    if len(absent_users) != 0:
+    if len(absent_users) != 0:    
         post_message('Here\'s who we\'re ignoring for now: ' + ', '.join(absent_users))
 
 def skip():
@@ -224,7 +212,7 @@ def skip():
 
 def table(topic_user, topic):
     global topics
-
+    
     channels = re.findall(r"<#(.*?)>", topic)
     users = re.findall(r"<@(.*?)>", topic)
 
@@ -235,7 +223,7 @@ def table(topic_user, topic):
     for user in users:
         user_name = get_user(user)
         topic = topic.replace('<@%s>' % user, '@%s' % user_name)
-
+    
     post_message('@%s: Tabled.' % topic_user)
     topics.append(str(topic))
 
@@ -244,12 +232,12 @@ def tabled():
     post_message('Tabled topics:')
     for topic in topics:
         post_message('-%s' % topic)
-
+        
 def giphy(text):
     url = 'http://api.giphy.com/v1/gifs/search?q=%s&api_key=dc6zaTOxFJmzC&limit=1' % urllib2.quote(text.encode("utf8"))
     response = urllib2.urlopen(url)
     data = json.loads(response.read())
-
+    
     if len(data['data']) == 0:
         post_message('Not sure what "%s" is.' % text)
     else:
@@ -259,35 +247,14 @@ def giphy(text):
             'title_link': data['data'][0]['url'],
             'image_url': data['data'][0]['images']['fixed_height']['url']
         }]
-
+    
         post_message('Not sure what "%s" is.' % text, json.dumps(attachments))
-
-def idle_users():
-    idle_users = []
-    channel_id = ''
-    channel_name = channel.replace('#', '') # for some reason we skip the # in this API call
-    all_channels = slack.channels.list(1) # 1 means we skip any archived rooms
-
-    for one_channel in all_channels.body['channels']:
-        if one_channel['name'] == channel_name:
-            channel_id = one_channel['id']
-
-    standup_room = slack.channels.info(channel_id).body['channel']
-    standup_users = standup_room['members']
-
-    for user_id in standup_users:
-        user_name = slack.users.info(user_id).body['user']['name']
-        if slack.users.get_presence(user_id).body['presence'] != 'active':
-            idle_users.append(user_name)
-
-    return idle_users
-
 
 def help(topic=''):
     if topic == '':
         post_message('My commands are !standup, !start, !cancel, !next, !skip, !table, !left, !ignore, !heed, and !ignoring.\nAsk me "!help <command> to learn what they do.')
         return
-
+        
     topic = topic[1:]
     if topic == 'standup' or topic == '!standup':
         post_message('Type !standup to initiate a new standup')
@@ -329,7 +296,7 @@ def main():
     command = match[0]
     args = text.replace("!%s" % command, '')
     command = command.lower()
-
+    
     if command not in commands:
         if giphy:
             giphy(text[1:])
@@ -339,7 +306,7 @@ def main():
     elif not in_progress and command != 'standup' and command != 'help' and command != 'ignore' and command != 'heed' and command != 'ignoring':
         post_message('Looks like standup hasn\'t started yet. Type !standup.')
         return json.dumps({ })
-
+        
     if command == 'standup':
         init()
     elif command == 'start':
@@ -362,7 +329,7 @@ def main():
         ignoring()
     elif command == 'help':
         help(args)
-
+        
     return json.dumps({ })
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 requests==2.2.1
 wsgiref==0.1.2
 gunicorn==18.0
-slacker==0.4.0
+slacker>=0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 requests==2.2.1
 wsgiref==0.1.2
 gunicorn==18.0
-slacker==0.9.15
+slacker>=0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 requests==2.2.1
 wsgiref==0.1.2
 gunicorn==18.0
-slacker>=0.5.4
+slacker==0.9.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 requests==2.2.1
 wsgiref==0.1.2
 gunicorn==18.0
-slacker==0.9.15
+slacker==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 requests==2.2.1
 wsgiref==0.1.2
 gunicorn==18.0
-slacker==0.4.0
+slacker==0.9.15


### PR DESCRIPTION
The bot will now check the env setting 'SKIP_IDLE_USERS' and if it's not 'false', will automatically skip users who are in the current channel, but have gone idle. This saves you from having to !skip people who leave the browser tab open but aren't in the current standup. It will print a list of the idle users being skipped at the start of the standup.